### PR TITLE
Add support for communication over TSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CometMock was tested with `go version go1.20.3 darwin/arm64`.
 To run CometMock, start your (cosmos-sdk) application instances with the flags ```--with-tendermint=false, --transport=grpc```.
 After the applications started, start CometMock like this
 ```
-cometmock {app_address1,app_address2,...} {genesis_file} {cometmock_listen_address} {home_folder1,home_folder2,...}
+cometmock {app_address1,app_address2,...} {genesis_file} {cometmock_listen_address} {home_folder1,home_folder2,...} {connection_mode}
 ```
 
 where 
@@ -34,6 +34,7 @@ where
 * the `genesis_file` is the genesis json that is also used by apps,
 * the `cometmock_listen_address` can be freely chosen and will be the address that requests that would normally go to CometBFT rpc endpoints need to be directed to
 * the `home_folders` are the home folders of the applications, in the same order as the `app_addresses`. This is required to use the private keys in the application folders to sign as appropriate validators.
+* connection mode is the protocol over which CometMock should connect to the ABCI application, either `grpc` or `socket`. See the `--transport` flag for Cosmos SDK applications. For SDK applications, just make sure `--transport` and this argument match, i.e. either both `socket` or both `grpc`.
 
 When calling the cosmos sdk cli, use as node address the `cometmock_listen_address`,
 e.g. `simd q bank total --node {cometmock_listen_address}`.


### PR DESCRIPTION
Instead of only supporting communication over grpc, now allow a choice between grpc and tsp (Tendermint Socket Protocol).
I introduced a new command line argument for this purpose.

```
go run ./cometmock localhost:36658,localhost:26658 genesis.json tcp://localhost:22331 /Users/offtermatt/simapp1,/Users/offtermatt/simapp2 _connectionMode_
```

connectionMode can either be `grpc` or `socket`.
This matches the choice for the application, which has the flag --transport with the same choices.

The following example works for me:
```
docker run --add-host=host.docker.internal:host-gateway --name simapp -p 26658:26658 -ti informalofftermatt/testnet:tendermock simd start _--transport=socket_ --with-tendermint=false --rpc.laddr=tcp://host.docker.internal:99999

docker run --add-host=host.docker.internal:host-gateway --name simapp2 -p 36658:26658 -ti informalofftermatt/testnet:tendermock simd start _--transport=socket_ --with-tendermint=false --grpc-only --rpc.laddr=tcp://host.docker.internal:99999

go run ./cometmock localhost:36658,localhost:26658 genesis.json tcp://localhost:22331 /Users/offtermatt/simapp1,/Users/offtermatt/simapp2 _socket_
```

Notice the _socket_ arguments.
Alternatively, running with grpc is still possible too:

```
docker run --add-host=host.docker.internal:host-gateway --name simapp -p 26658:26658 -ti informalofftermatt/testnet:tendermock simd start _--transport=grpc_ --with-tendermint=false --rpc.laddr=tcp://host.docker.internal:99999

docker run --add-host=host.docker.internal:host-gateway --name simapp2 -p 36658:26658 -ti informalofftermatt/testnet:tendermock simd start _--transport=grpc_ --with-tendermint=false --grpc-only --rpc.laddr=tcp://host.docker.internal:99999

go run ./cometmock localhost:36658,localhost:26658 genesis.json tcp://localhost:22331 /Users/offtermatt/simapp1,/Users/offtermatt/simapp2 _grpc_
```