### PR TITLE
Update README.md to mention version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ controlling which validators sign blocks,
 
 On a technical level, CometMock communicates with applications via ABCI through GRPC or TSP (Tendermint Socket Protocol) calls. It calls BeginBlock, DeliverTx, EndBlock and Commit like CometBFT does during normal execution.
 
-Currently, CometMock imitates CometBFT v0.34. It offers *many* of the RPC endpoints offered by Comet (https://docs.cometbft.com/v0.34/rpc/),
+Currently, CometMock maintains releases compatible with CometBFT v0.37 and v0.34. It offers *many* of the RPC endpoints offered by Comet (see https://docs.cometbft.com/v0.34/rpc/ and https://docs.cometbft.com/v0.37/rpc/ for the respective version of the interface),
 in particular it supports the subset used by Gorelayer (https://github.com/cosmos/relayer/).
 See the endpoints offered here: [https://github.com/p-offtermatt/CometMock/cometmock/rpc_server/routes.go#L30C2-L53](https://github.com/informalsystems/CometMock/blob/main/cometmock/rpc_server/routes.go)
 


### PR DESCRIPTION
Since adding a line compatible with CometBFT v0.37, the README became outdated, as it talks only about v0.34.
This pr collects improvements to the README that solve this.