### PR TITLE
Make timeout on chain startup longer

### DIFF
--- a/cometmock/abci_client/client.go
+++ b/cometmock/abci_client/client.go
@@ -355,7 +355,7 @@ func (a *AbciClient) SendInitChain(genesisState state.State, genesisDoc *types.G
 	f := func(client AbciCounterpartyClient) (interface{}, error) {
 		return client.Client.InitChainSync(*initChainRequest)
 	}
-	responses, err := a.callClientsWithTimeout(f, 500*time.Millisecond)
+	responses, err := a.callClientsWithTimeout(f, 20*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The InitChain hook timed out for me using the penumbra app - the previous timeout was 500ms, but the penumbra app takes about 2s on InitChain.

This PR lengthens the time to avoid timeouts when used with penumbra.