### PR TITLE
Fix the backport action by fetching branches before backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Fetch all branches
+    run: git fetch origin v0.34.x:v0.34.x
+
     - name: Install Hub CLI
       run: sudo snap install --classic hub
 
@@ -28,6 +31,9 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
+
+    - name: Fetch all branches
+    run: git fetch origin v0.37.x:v0.37.x
 
     - name: Install Hub CLI
       run: sudo snap install --classic hub


### PR DESCRIPTION
Fixes a bug in the backport action: Branches need to be fetched before they are checked out