### PR TITLE
Fix behaviour of blocktime

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ CometMock was tested with `go version go1.20.3 darwin/arm64`.
 To run CometMock, start your (cosmos-sdk) application instances with the flags ```--with-tendermint=false, --transport=grpc```.
 After the applications started, start CometMock like this
 ```
-cometmock {app_address1,app_address2,...} {genesis_file} {cometmock_listen_address} {home_folder1,home_folder2,...} {connection_mode} [--block-time=XXX]
+cometmock [--block-time=XXX] {app_address1,app_address2,...} {genesis_file} {cometmock_listen_address} {home_folder1,home_folder2,...} {connection_mode}
 ```
 
 where: 
+* The `--block-time` flag is optional and specifies the time in milliseconds between blocks. The default is 1000ms(=1s). Values <= 0 mean that automatic block production is disabled. In this case, blocks can be produced by calling the `advance_blocks` endpoint or by broadcasting transactions (each transaction will be included in a fresh block). Note that all flags have to come before positional arguments.
 * The `app_addresses` are the `--address` flags of the applications. This is by default `"tcp://0.0.0.0:26658"`
 * The `genesis_file` is the genesis json that is also used by apps.
 * The `cometmock_listen_address` can be freely chosen and will be the address that requests that would normally go to CometBFT rpc endpoints need to be directed to.
 * The `home_folders` are the home folders of the applications, in the same order as the `app_addresses`. This is required to use the private keys in the application folders to sign as appropriate validators.
 * Connection mode is the protocol over which CometMock should connect to the ABCI application, either `grpc` or `socket`. See the `--transport` flag for Cosmos SDK applications. For SDK applications, just make sure `--transport` and this argument match, i.e. either both `socket` or both `grpc`.
-* The `--block-time` flag is optional and specifies the time in milliseconds between blocks. The default is 1000ms(=1s). Values <= 0 mean that automatic block production is disabled. In this case, blocks can be produced by calling the `advance_blocks` endpoint or by broadcasting transactions (each transaction will be included in a fresh block).
 
 When calling the cosmos sdk cli, use as node address the `cometmock_listen_address`,
 e.g. `simd q bank total --node {cometmock_listen_address}`.

--- a/cometmock/main.go
+++ b/cometmock/main.go
@@ -73,7 +73,7 @@ advancing blocks or broadcasting transactions.`,
 				return cli.Exit(fmt.Sprintf("Invalid connection mode: %s. Connection mode must be either 'socket' or 'grpc'.\nUsage: %s", connectionMode, argumentString), 1)
 			}
 
-			blockTime := c.Int("blocktime")
+			blockTime := c.Int("block-time")
 			fmt.Printf("Block time: %d\n", blockTime)
 
 			// read node homes from args
@@ -166,7 +166,7 @@ advancing blocks or broadcasting transactions.`,
 			go rpc_server.StartRPCServerWithDefaultConfig(cometMockListenAddress, logger)
 
 			if blockTime > 0 {
-				// produce a block every second
+				// produce blocks according to blockTime
 				for {
 					_, _, _, _, _, err := abci_client.GlobalClient.RunBlock(nil)
 					if err != nil {

--- a/cometmock/main.go
+++ b/cometmock/main.go
@@ -54,8 +54,7 @@ This will not necessarily mean block production is this fast
 Setting this to a value <= 0 disables automatic block production.
 In this case, blocks are only produced when instructed explicitly either by
 advancing blocks or broadcasting transactions.`,
-				Value:    1000,
-				Required: true,
+				Value: 1000,
 			},
 		},
 		ArgsUsage: argumentString,

--- a/cometmock/main.go
+++ b/cometmock/main.go
@@ -38,14 +38,13 @@ func GetMockPVsFromNodeHomes(nodeHomes []string) []types.PrivValidator {
 func main() {
 	logger := cometlog.NewTMLogger(cometlog.NewSyncWriter(os.Stdout))
 
-	argumentString := "<app-addresses> <genesis-file> <cometmock-listen-address> <node-homes> <abci-connection-mode> [--block-time=value]"
+	argumentString := "[--block-time=value] <app-addresses> <genesis-file> <cometmock-listen-address> <node-homes> <abci-connection-mode>"
 
 	app := &cli.App{
 		Name:            "cometmock",
 		HideHelpCommand: true,
-		Usage:           "Your application description",
 		Flags: []cli.Flag{
-			&cli.IntFlag{
+			&cli.Int64Flag{
 				Name: "block-time",
 				Usage: `
 Time between blocks in milliseconds.
@@ -55,7 +54,8 @@ This will not necessarily mean block production is this fast
 Setting this to a value <= 0 disables automatic block production.
 In this case, blocks are only produced when instructed explicitly either by
 advancing blocks or broadcasting transactions.`,
-				Value: 1000,
+				Value:    1000,
+				Required: true,
 			},
 		},
 		ArgsUsage: argumentString,
@@ -74,7 +74,7 @@ advancing blocks or broadcasting transactions.`,
 				return cli.Exit(fmt.Sprintf("Invalid connection mode: %s. Connection mode must be either 'socket' or 'grpc'.\nUsage: %s", connectionMode, argumentString), 1)
 			}
 
-			blockTime := c.Int("block-time")
+			blockTime := c.Int("blocktime")
 			fmt.Printf("Block time: %d\n", blockTime)
 
 			// read node homes from args

--- a/cometmock/main.go
+++ b/cometmock/main.go
@@ -166,15 +166,21 @@ advancing blocks or broadcasting transactions.`,
 
 			go rpc_server.StartRPCServerWithDefaultConfig(cometMockListenAddress, logger)
 
-			// produce a block every second
-			for {
-				_, _, _, _, _, err := abci_client.GlobalClient.RunBlock(nil)
-				if err != nil {
-					logger.Error(err.Error())
-					panic(err)
+			if blockTime > 0 {
+				// produce a block every second
+				for {
+					_, _, _, _, _, err := abci_client.GlobalClient.RunBlock(nil)
+					if err != nil {
+						logger.Error(err.Error())
+						panic(err)
+					}
+					time.Sleep(time.Millisecond * time.Duration(blockTime))
 				}
-				time.Sleep(1 * time.Second)
+			} else {
+				// wait forever
+				time.Sleep(time.Hour * 24 * 365 * 100) // 100 years
 			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
The order of aguments for blocktime was not listed correctly. The CLI library I am using is very particular w.r.t ordering, so now I list the order correctly.

This also actually changes the behaviour according to the blocktime flag, which was removed from the PR before due to merge conflicts.