### PR TITLE
Fix: return the block from storage, not the latest block

### DIFF
--- a/cometmock/rpc_server/routes.go
+++ b/cometmock/rpc_server/routes.go
@@ -622,7 +622,7 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 		return nil, err
 	}
 
-	return &ctypes.ResultBlock{BlockID: *blockID, Block: abci_client.GlobalClient.LastBlock}, nil
+	return &ctypes.ResultBlock{BlockID: *blockID, Block: block}, nil
 }
 
 // BlockResults gets ABCIResults at a given height.


### PR DESCRIPTION
Manual backport because this was done as part of https://github.com/informalsystems/CometMock/pull/71