### PR TITLE
Use CometMock address for rpc.laddr

### DIFF
--- a/e2e-tests/local-testnet-debug.sh
+++ b/e2e-tests/local-testnet-debug.sh
@@ -188,7 +188,7 @@ do
         --home ${PROV_NODE_DIR} \
         --transport=grpc --with-tendermint=false \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr ${PROVIDER_COMETMOCK_ADDR} \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \
@@ -388,7 +388,7 @@ do
         --home ${CONS_NODE_DIR} \
         --transport=grpc --with-tendermint=false \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr ${CONSUMER_COMETMOCK_ADDR} \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \

--- a/e2e-tests/local-testnet-singlechain-cometbft.sh
+++ b/e2e-tests/local-testnet-singlechain-cometbft.sh
@@ -192,7 +192,7 @@ do
     $BINARY_NAME start \
         --home ${PROV_NODE_DIR} \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr ${PROVIDER_COMETMOCK_ADDR} \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \

--- a/e2e-tests/local-testnet-singlechain.sh
+++ b/e2e-tests/local-testnet-singlechain.sh
@@ -193,7 +193,7 @@ do
         --home ${PROV_NODE_DIR} \
         --transport=grpc --with-tendermint=false \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr $PROVIDER_COMETMOCK_ADDR \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \

--- a/e2e-tests/local-testnet.sh
+++ b/e2e-tests/local-testnet.sh
@@ -187,7 +187,7 @@ do
         --home ${PROV_NODE_DIR} \
         --transport=grpc --with-tendermint=false \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr ${PROVIDER_COMETMOCK_ADDR} \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \
@@ -384,7 +384,7 @@ do
         --home ${CONS_NODE_DIR} \
         --transport=grpc --with-tendermint=false \
         --p2p.persistent_peers ${PERSISTENT_PEERS} \
-        --rpc.laddr tcp://${NODE_IP}:${RPC_LADDR_PORT} \
+        --rpc.laddr ${CONSUMER_COMETMOCK_ADDR} \
         --grpc.address ${NODE_IP}:${GRPC_LADDR_PORT} \
         --address tcp://${NODE_IP}:${NODE_ADDRESS_PORT} \
         --p2p.laddr tcp://${NODE_IP}:${P2P_LADDR_PORT} \


### PR DESCRIPTION
Can be merged to enable compatibility with the Cosmos SDK gRPC fix from https://github.com/cosmos/cosmos-sdk/pull/18110
Merging this and running with an SDK version before this upgrade should not cause any issues.