### PR TITLE
Enable tags only for semver and default branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
 
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -66,6 +67,12 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{github.ref == 'refs/heads/main'}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}},value=v${{ inputs.tags }},enable=${{ inputs.tags != '' }}
+          flavor: |
+            latest=false
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Closes: https://github.com/informalsystems/CometMock/issues/81

Right now, tags are generated for a lot of Docker images that are generated by the automated workflow https://github.com/informalsystems/CometMock/blob/ph/produce-less-tagged-images/.github/workflows/docker-publish.yml

This should be adjusted to have only the following tags auto-generated:
* main
* nightly
* 0.x.x semver-tagged images